### PR TITLE
docs: fix README typo

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -59,7 +59,7 @@ For any TCPIP connection, you need to provide:
 95 PRINT"TIMED OUT":END        <--- Give up
 ```
 
-6) Connection is now established, you can transmit and recieve data
+6) Connection is now established, you can transmit and receive data
 
 The library automatically uses the A$ variable for sending strings:
 
@@ -76,5 +76,4 @@ The library automatically uses the A$ variable for sending strings:
 ```SYS $42021```
 
 TODO: document statuses, DNS lookup, and Listener mode
-
 


### PR DESCRIPTION
### Summary

Fixes a spelling typo in the README.

### Verification

- Documentation-only change; no runtime tests needed.